### PR TITLE
proper "exports" field in package.json files

### DIFF
--- a/.changeset/lemon-eagles-hug.md
+++ b/.changeset/lemon-eagles-hug.md
@@ -1,0 +1,7 @@
+---
+"@userfront/react": minor
+"@userfront/next": minor
+"@userfront/node": minor
+---
+
+proper "exports" field in package.json files

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -21,10 +21,19 @@
     "dist"
   ],
   "exports": {
-    "./client": "./dist/client.js",
+    "./client": {
+      "types": "./dist/client.d.ts",
+      "default": "./dist/client.js"
+    },
     "./server": {
-      "import": "./dist/server.mjs",
-      "require": "./dist/server.js"
+      "import": {
+        "types": "./dist/server.d.mts",
+        "default": "./dist/server.mjs"
+      },
+      "require": {
+        "types": "./dist/server.d.ts",
+        "default": "./dist/server.js"
+      }
     }
   },
   "scripts": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -21,6 +21,16 @@
   ],
   "main": "dist/index.js",
   "module": "dist/index.mjs",
+  "exports": {
+    "import": {
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
+    },
+    "require": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -21,6 +21,16 @@
   ],
   "main": "dist/index.js",
   "module": "dist/index.mjs",
+  "exports": {
+    "import": {
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
+    },
+    "require": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "tsup --cjsInterop",
     "dev": "tsup --watch --cjsInterop",


### PR DESCRIPTION
Review Level: Glance

# Description
Add `exports` field to package.json, without it TS definition in VS Code doesn't work.




## Additional Details

# Motivation
![image](https://github.com/user-attachments/assets/5ed82f06-0dd9-48d2-acd2-1c3ae6599fea)
